### PR TITLE
Fix readme markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Framework for allocating memory in #![no_std] modules.
+# Framework for allocating memory in `#![no_std]` modules.
 
 [![crates.io](http://meritbadge.herokuapp.com/alloc-no-stdlib)](https://crates.io/crates/alloc-no-stdlib)
 [![Build Status](https://travis-ci.org/dropbox/rust-alloc-no-stdlib.svg?branch=master)](https://travis-ci.org/dropbox/rust-alloc-no-stdlib)
@@ -8,7 +8,7 @@
  * Rust 1.6
 
 ## Documentation
-Currently there is no standard way to allocate memory from within a module that is no_std.
+Currently there is no standard way to allocate memory from within a module that is `no_std`.
 This provides a mechanism to describe a memory allocation that can be satisfied entirely on
 the stack, by unsafely linking to calloc, or by unsafely referencing a mutable global variable.
 This library currently will leak memory if free_cell isn't specifically invoked on memory.
@@ -31,8 +31,7 @@ limits the program to only a few megs of dynamically allocated data
 
 Example:
 
-```
-
+```rust
 // First define a struct to hold all the array on the stack.
 declare_stack_allocator_struct!(StackAllocatedFreelist4, 4, stack);
 // since generics cannot be used, the actual struct to hold the memory must be defined with a macro
@@ -61,6 +60,7 @@ declare_stack_allocator_struct!(StackAllocatedFreelist4, 4, stack);
 ### On the heap
 This uses the standard Box facilities to allocate memory
 
+```rust
   let mut halloc = HeapAlloc::<u8>::new(0);
   for _i in 1..10 { // heap test
       let mut x = halloc.alloc_cell(100000);
@@ -75,11 +75,13 @@ This uses the standard Box facilities to allocate memory
       assert_eq!(x[9], 0);
       assert_eq!(z[0], 6);
   }
+```
 
 ### On the heap, but uninitialized
 This does allocate data every time it is requested, but it does not allocate the
 memory, so naturally it is unsafe. The caller must initialize the memory properly
-```
+
+```rust
   let mut halloc = unsafe{HeapAllocUninitialized::<u8>::new()};
   { // heap test
       let mut x = halloc.alloc_cell(100000);
@@ -95,14 +97,14 @@ memory, so naturally it is unsafe. The caller must initialize the memory properl
       assert_eq!(z[0], 6);
       ...
    }
-
+```
 
 ### On the heap in a single pool allocation
 This does a single big allocation on the heap, after which no further usage of the stdlib
 will happen. This can be useful for a jailed application that wishes to restrict syscalls
 at this point
 
-```
+```rust
 use alloc_no_stdlib::HeapPrealloc;
 ...
   let mut heap_global_buffer = define_allocator_memory_pool!(4096, u8, [0; 6 * 1024 * 1024], heap);
@@ -126,7 +128,7 @@ will happen. This can be useful for a jailed application that wishes to restrict
 at this point. This option keep does not set the memory to a valid value, so it is
 necessarily marked unsafe
 
-```
+```rust
 use alloc_no_stdlib::HeapPrealloc;
 ...
   let mut heap_global_buffer = unsafe{HeapPrealloc::<u8>::new_uninitialized_memory_pool(6 * 1024 * 1024)};
@@ -142,13 +144,13 @@ use alloc_no_stdlib::HeapPrealloc;
   }
 ```
 
-### With calloc
+### With `calloc`
 This is the most efficient way to get a zero'd dynamically sized buffer without the stdlib
 It does invoke the C calloc function and hence must invoke unsafe code.
 In this version, the number of cells are fixed to the parameter specified in the struct definition
 (4096 in this example)
 
-```
+```rust
 extern {
   fn calloc(n_elem : usize, el_size : usize) -> *mut u8;
   fn malloc(len : usize) -> *mut u8;
@@ -180,12 +182,12 @@ structure. Accessing mutable static variables requires unsafe code; however,
 so this code will invoke an unsafe block.
 
 
-Make sure to only reference global_buffer in a single place, at a single time in the code
+Make sure to only reference `global_buffer` in a single place, at a single time in the code
 If it is used from two places or at different times, undefined behavior may result,
-since multiple allocators may get access to global_buffer.
+since multiple allocators may get access to `global_buffer`.
 
 
-```
+```rust
 declare_stack_allocator_struct!(GlobalAllocatedFreelist, 16, global);
 define_allocator_memory_pool!(16, u8, [0; 1024 * 1024 * 100], global, global_buffer);
 


### PR DESCRIPTION
One of the code blocks was missing closing backticks and messed up the rest of the formatting. I also enabled syntax highlighting. 