### PR TITLE
forget() is no-op in CallocBackingStore's Drop implementation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,8 +74,7 @@ impl<'a, T : 'a> CallocBackingStore<'a, T> {
 }
 impl<'a, T:'a> Drop for CallocBackingStore<'a, T> {
   fn drop(self :&mut Self) {
-//      core::mem::forget(core::mem::replace(self.data, &mut[]));
-    core::mem::forget(core::mem::replace(&mut self.data, &mut[]));
+    _ = core::mem::take(&mut self.data);
     if !self.raw_data.is_null() {
       let local_free = self.free;
       unsafe {(local_free)(self.raw_data)};


### PR DESCRIPTION
Calling core::mem::forget() for slice is no-op. Forget wants to have an ownership of the data, but it can't since slice is always a reference. While here, use take() instead of replace() as recommended by Clippy.

This should not have any functional change, but it should remove the emitted compile time warning:

```
  --> /Users/oherrala/.cargo/registry/src/index.crates.io-6f17d22bba15001f/alloc-no-stdlib-2.0.4/src/lib.rs:78:5
   |
78 |     core::mem::forget(core::mem::replace(&mut self.data, &mut[]));
   |     ^^^^^^^^^^^^^^^^^^------------------------------------------^
   |                       |
   |                       argument has type `&mut [T]`
   |
   = note: use `let _ = ...` to ignore the expression or result
   = note: `#[warn(forgetting_references)]` on by default
```
