### PR TITLE
Restrict alloc-stdlib dependency to alloc-no-stdlib 2.0.4

### DIFF
--- a/alloc-stdlib/Cargo.toml
+++ b/alloc-stdlib/Cargo.toml
@@ -15,7 +15,7 @@ autobins = false
 name = "example"
 
 [dependencies]
-"alloc-no-stdlib" = { version=">=2.0.4, <4.0.0", path="../"}
+"alloc-no-stdlib" = { version="2.0.4", path="../"}
 
 [features]
 unsafe = ["alloc-no-stdlib/unsafe"]


### PR DESCRIPTION
## What changed

Restrict `alloc-stdlib`'s `alloc-no-stdlib` dependency back to the current `2.0.4` package line.

## Why

`alloc-stdlib` re-exports `alloc-no-stdlib` traits and implements those traits for `StandardAlloc`, so `alloc-no-stdlib` is part of its public API surface.

Allowing `alloc-stdlib 0.2.3` to resolve against `alloc-no-stdlib 3.x` can split downstream trait identities when another crate in the same graph still depends on `alloc-no-stdlib 2.x`. One observed case is `brotli 8.0.3`, where a fresh no-lock resolution can select `alloc-no-stdlib 2.0.4` for `brotli` and `alloc-no-stdlib 3.0.0` for `alloc-stdlib`, causing `StandardAlloc` not to satisfy `brotli`'s `Allocator<T>` bounds.

Fixes #22.

## Validation

Passed:

```text
cargo test
cargo test --features=unsafe --release
cd alloc-stdlib && cargo test
```

Existing failure observed:

```text
cd alloc-stdlib && cargo test --release --features=unsafe
```

This fails in the existing `HeapAllocUninitialized::<u8>::new()` test call because the function now requires an argument. That failure is unrelated to this dependency constraint change.
